### PR TITLE
Extract workspace and trash handlers

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -52,6 +52,8 @@ import { useImageExporter } from './hooks/useImageExporter';
 import { useBroadcastChannel, BroadcastMessageType } from './hooks/useBroadcastChannel';
 import { useRealtimeSync } from './hooks/useRealtimeSync';
 import { useSidebarHandlers } from './hooks/useSidebarHandlers';
+import { useTrashHandlers } from './hooks/useTrashHandlers';
+import { useWorkspaceCallbacks } from './hooks/useWorkspaceCallbacks';
 
 // Lib & Types
 import { localPersistence } from './lib/localPersistence';
@@ -63,7 +65,6 @@ import {
   SidebarInset,
   SidebarProvider,
 } from "@/components/ui/sidebar"
-
 
 // Helper to check for share routes
 const getSharePathInfo = () => {
@@ -142,11 +143,6 @@ function AppContent() {
   const notesSaveTimeout = useRef<NodeJS.Timeout | null>(null);
   const drawingsSaveTimeout = useRef<NodeJS.Timeout | null>(null);
   const flowchartsSaveTimeout = useRef<NodeJS.Timeout | null>(null);
-
-
-
-
-
 
   // Search State
   const [searchQuery, setSearchQuery] = useState("");
@@ -284,7 +280,6 @@ function AppContent() {
   useEffect(() => { nodesRef.current = nodes; }, [nodes]);
   useEffect(() => { edgesRef.current = edges; }, [edges]);
 
-
   // Handlers
   // Computed Values
   const {
@@ -294,7 +289,6 @@ function AppContent() {
     activeNote,
     activeDrawing,
     activeFlowchart,
-    activeDiagram,
     featureLabel,
     activeFileName,
     activeProjectName,
@@ -1158,124 +1152,48 @@ function AppContent() {
     }
   };
 
+  const {
+    handleNodeClick,
+    handleNodeDoubleClick,
+    handleEdgeClick,
+    handlePaneClick,
+    handleMove,
+    handleOpenImportModal,
+    handleWorkspaceExportSQL,
+    handleWorkspaceExportPDF,
+    handleWorkspaceExportImage,
+    workspaceIsLoading,
+  } = useWorkspaceCallbacks({
+    isPublicView, setSelectedNodeId, setSelectedEdgeId,
+    setIsTablePropertiesOpen, setIsImportModalOpen,
+    viewportRef,
+    publicData, diagrams, activeDiagramId,
+    handleExportSQL, handleExportPDF, handleExportImage,
+    nodes, edges,
+    view,
+    isDiagramsLoading, isERDItemLoading,
+    isNotesLoading, isNoteItemLoading,
+    isDrawingsLoading, isDrawingItemLoading,
+    isFlowchartsLoading, isFlowchartItemLoading,
+  });
 
-
-  // 🛡️ Stabilized callbacks for WorkspaceContent memo boundary
-  const handleNodeClick = useCallback((e: React.MouseEvent, n: Node) => {
-    if (!isPublicView && !(e.target as HTMLElement).closest('.nodrag')) setSelectedNodeId(n.id);
-  }, [isPublicView, setSelectedNodeId]);
-
-  const handleNodeDoubleClick = useCallback((e: React.MouseEvent, n: Node) => {
-    if (!isPublicView && !(e.target as HTMLElement).closest('.nodrag')) {
-      setSelectedNodeId(n.id);
-      setIsTablePropertiesOpen(true);
-    }
-  }, [isPublicView, setSelectedNodeId, setIsTablePropertiesOpen]);
-
-  const handleEdgeClick = useCallback((_: any, e: Edge) => {
-    if (!isPublicView) setSelectedEdgeId(e.id);
-  }, [isPublicView, setSelectedEdgeId]);
-
-  const handlePaneClick = useCallback(() => {
-    setSelectedNodeId(null);
-    setSelectedEdgeId(null);
-  }, [setSelectedNodeId, setSelectedEdgeId]);
-
-  const handleMove = useCallback((_: any, v: any) => {
-    viewportRef.current = v;
-  }, [viewportRef]);
-
-  const handleOpenImportModal = useCallback(() => {
-    setIsImportModalOpen(true);
-  }, [setIsImportModalOpen]);
-
-  const handleWorkspaceExportSQL = useCallback((dialect: 'postgresql' | 'mysql') => {
-    const target = isPublicView ? publicData : diagrams.find(f => f.id === activeDiagramId);
-    if (target) handleExportSQL(dialect, target, nodes, edges);
-  }, [isPublicView, publicData, diagrams, activeDiagramId, handleExportSQL, nodes, edges]);
-
-  const handleWorkspaceExportPDF = useCallback(() => {
-    const targetName = isPublicView
-      ? (publicData?.name || 'Shared')
-      : (diagrams.find(f => f.id === activeDiagramId)?.name || 'Diagram');
-    handleExportPDF(targetName);
-  }, [isPublicView, publicData, diagrams, activeDiagramId, handleExportPDF]);
-
-  const handleWorkspaceExportImage = useCallback(() => {
-    const targetName = isPublicView
-      ? (publicData?.name || 'Shared')
-      : (diagrams.find(f => f.id === activeDiagramId)?.name || 'Diagram');
-    handleExportImage(targetName);
-  }, [isPublicView, publicData, diagrams, activeDiagramId, handleExportImage]);
-
-  // 🛡️ TrashView stabilized callbacks
-  const handleTrashRestoreProject = useCallback(async (id: any) => {
-    await restoreProject(id);
-    await fetchTrash();
-    await fetchProjects();
-  }, [restoreProject, fetchTrash, fetchProjects]);
-
-  const handleTrashRestoreDiagram = useCallback(async (id: any) => {
-    await restoreDiagram(id);
-    await fetchTrash();
-    await fetchProjects();
-    await fetchDiagrams(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
-  }, [restoreDiagram, fetchTrash, fetchProjects, fetchDiagrams, debouncedSearchQuery]);
-
-  const handleTrashRestoreNote = useCallback(async (id: any) => {
-    await restoreNote(id);
-    await fetchTrash();
-    await fetchProjects();
-    await fetchNotes(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
-  }, [restoreNote, fetchTrash, fetchProjects, fetchNotes, debouncedSearchQuery]);
-
-  const handleTrashRestoreDrawing = useCallback(async (id: any) => {
-    await restoreDrawing(id);
-    await fetchTrash();
-    await fetchProjects();
-    await fetchDrawings(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
-  }, [restoreDrawing, fetchTrash, fetchProjects, fetchDrawings, debouncedSearchQuery]);
-
-  const handleTrashRestoreFlowchart = useCallback(async (id: any) => {
-    await restoreFlowchart(id);
-    await fetchTrash();
-    await fetchProjects();
-    await fetchFlowcharts(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
-  }, [restoreFlowchart, fetchTrash, fetchProjects, fetchFlowcharts, debouncedSearchQuery]);
-
-  const handleTrashProjectPermanentDelete = useCallback((id: any) => {
-    setItemToDelete({ id, type: 'project' });
-    setIsPermanentDeleteConfirmOpen(true);
-  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
-
-  const handleTrashDiagramPermanentDelete = useCallback((id: any) => {
-    setItemToDelete({ id, type: 'erd' });
-    setIsPermanentDeleteConfirmOpen(true);
-  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
-
-  const handleTrashNotePermanentDelete = useCallback((id: any) => {
-    setItemToDelete({ id, type: 'notes' });
-    setIsPermanentDeleteConfirmOpen(true);
-  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
-
-  const handleTrashDrawingPermanentDelete = useCallback((id: any) => {
-    setItemToDelete({ id, type: 'drawings' });
-    setIsPermanentDeleteConfirmOpen(true);
-  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
-
-  const handleTrashFlowchartPermanentDelete = useCallback((id: any) => {
-    setItemToDelete({ id, type: 'flowchart' as any });
-    setIsPermanentDeleteConfirmOpen(true);
-  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
-
-  // Compute loading state for current view only (avoids passing view-specific loading to WorkspaceContent)
-  const workspaceIsLoading = useMemo(() => {
-    if (view === 'erd') return isDiagramsLoading || isERDItemLoading;
-    if (view === 'notes') return isNotesLoading || isNoteItemLoading;
-    if (view === 'drawings') return isDrawingsLoading || isDrawingItemLoading;
-    if (view === 'flowchart') return isFlowchartsLoading || isFlowchartItemLoading;
-    return false;
-  }, [view, isDiagramsLoading, isERDItemLoading, isNotesLoading, isNoteItemLoading, isDrawingsLoading, isDrawingItemLoading, isFlowchartsLoading, isFlowchartItemLoading]);
+  const {
+    handleTrashRestoreProject,
+    handleTrashRestoreDiagram,
+    handleTrashRestoreNote,
+    handleTrashRestoreDrawing,
+    handleTrashRestoreFlowchart,
+    handleTrashProjectPermanentDelete,
+    handleTrashDiagramPermanentDelete,
+    handleTrashNotePermanentDelete,
+    handleTrashDrawingPermanentDelete,
+    handleTrashFlowchartPermanentDelete,
+  } = useTrashHandlers({
+    restoreProject, restoreDiagram, restoreNote, restoreDrawing, restoreFlowchart,
+    fetchTrash, fetchProjects, fetchDiagrams, fetchNotes, fetchDrawings, fetchFlowcharts,
+    debouncedSearchQuery,
+    setItemToDelete, setIsPermanentDeleteConfirmOpen,
+  });
 
   if (isAuthenticated === null && !isPublicView) return <AppInitialization type="init" />;
   if (isPublicLoading) return <AppInitialization type="public" view={view} />;
@@ -1343,7 +1261,6 @@ function AppContent() {
           isTrashLoading={isTrashLoading}
         />
       )}
-
 
       <SidebarInset className={isPublicView ? "w-full" : ""}>
         <MainHeader 

--- a/src/hooks/useTrashHandlers.ts
+++ b/src/hooks/useTrashHandlers.ts
@@ -1,0 +1,99 @@
+import { useCallback } from 'react';
+
+export interface UseTrashHandlersParams {
+  restoreProject: (id: any) => Promise<void>;
+  restoreDiagram: (id: any) => Promise<void>;
+  restoreNote: (id: any) => Promise<void>;
+  restoreDrawing: (id: any) => Promise<void>;
+  restoreFlowchart: (id: any) => Promise<void>;
+  fetchTrash: () => Promise<void>;
+  fetchProjects: (loadMore?: boolean, searchQuery?: string) => Promise<void>;
+  fetchDiagrams: (loadMore?: boolean, projectId?: any, searchQuery?: string, isPublic?: boolean | null, limit?: number, options?: any) => Promise<void>;
+  fetchNotes: (loadMore?: boolean, projectId?: any, searchQuery?: string, isPublic?: boolean | null, limit?: number, options?: any) => Promise<void>;
+  fetchDrawings: (loadMore?: boolean, projectId?: any, searchQuery?: string, isPublic?: boolean | null, limit?: number, options?: any) => Promise<void>;
+  fetchFlowcharts: (loadMore?: boolean, projectId?: any, searchQuery?: string, isPublic?: boolean | null, limit?: number, options?: any) => Promise<void>;
+  debouncedSearchQuery: string;
+  setItemToDelete: (value: any) => void;
+  setIsPermanentDeleteConfirmOpen: (open: boolean) => void;
+}
+
+export function useTrashHandlers(params: UseTrashHandlersParams) {
+  const {
+    restoreProject, restoreDiagram, restoreNote, restoreDrawing, restoreFlowchart,
+    fetchTrash, fetchProjects, fetchDiagrams, fetchNotes, fetchDrawings, fetchFlowcharts,
+    debouncedSearchQuery,
+    setItemToDelete, setIsPermanentDeleteConfirmOpen,
+  } = params;
+
+  const handleTrashRestoreProject = useCallback(async (id: any) => {
+    await restoreProject(id);
+    await fetchTrash();
+    await fetchProjects();
+  }, [restoreProject, fetchTrash, fetchProjects]);
+
+  const handleTrashRestoreDiagram = useCallback(async (id: any) => {
+    await restoreDiagram(id);
+    await fetchTrash();
+    await fetchProjects();
+    await fetchDiagrams(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
+  }, [restoreDiagram, fetchTrash, fetchProjects, fetchDiagrams, debouncedSearchQuery]);
+
+  const handleTrashRestoreNote = useCallback(async (id: any) => {
+    await restoreNote(id);
+    await fetchTrash();
+    await fetchProjects();
+    await fetchNotes(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
+  }, [restoreNote, fetchTrash, fetchProjects, fetchNotes, debouncedSearchQuery]);
+
+  const handleTrashRestoreDrawing = useCallback(async (id: any) => {
+    await restoreDrawing(id);
+    await fetchTrash();
+    await fetchProjects();
+    await fetchDrawings(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
+  }, [restoreDrawing, fetchTrash, fetchProjects, fetchDrawings, debouncedSearchQuery]);
+
+  const handleTrashRestoreFlowchart = useCallback(async (id: any) => {
+    await restoreFlowchart(id);
+    await fetchTrash();
+    await fetchProjects();
+    await fetchFlowcharts(false, 'all', debouncedSearchQuery, null, 50, { silent: true });
+  }, [restoreFlowchart, fetchTrash, fetchProjects, fetchFlowcharts, debouncedSearchQuery]);
+
+  const handleTrashProjectPermanentDelete = useCallback((id: any) => {
+    setItemToDelete({ id, type: 'project' });
+    setIsPermanentDeleteConfirmOpen(true);
+  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
+
+  const handleTrashDiagramPermanentDelete = useCallback((id: any) => {
+    setItemToDelete({ id, type: 'erd' });
+    setIsPermanentDeleteConfirmOpen(true);
+  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
+
+  const handleTrashNotePermanentDelete = useCallback((id: any) => {
+    setItemToDelete({ id, type: 'notes' });
+    setIsPermanentDeleteConfirmOpen(true);
+  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
+
+  const handleTrashDrawingPermanentDelete = useCallback((id: any) => {
+    setItemToDelete({ id, type: 'drawings' });
+    setIsPermanentDeleteConfirmOpen(true);
+  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
+
+  const handleTrashFlowchartPermanentDelete = useCallback((id: any) => {
+    setItemToDelete({ id, type: 'flowchart' as any });
+    setIsPermanentDeleteConfirmOpen(true);
+  }, [setItemToDelete, setIsPermanentDeleteConfirmOpen]);
+
+  return {
+    handleTrashRestoreProject,
+    handleTrashRestoreDiagram,
+    handleTrashRestoreNote,
+    handleTrashRestoreDrawing,
+    handleTrashRestoreFlowchart,
+    handleTrashProjectPermanentDelete,
+    handleTrashDiagramPermanentDelete,
+    handleTrashNotePermanentDelete,
+    handleTrashDrawingPermanentDelete,
+    handleTrashFlowchartPermanentDelete,
+  };
+}

--- a/src/hooks/useWorkspaceCallbacks.ts
+++ b/src/hooks/useWorkspaceCallbacks.ts
@@ -1,0 +1,113 @@
+import { useCallback, useMemo } from 'react';
+import { Node, Edge } from '@xyflow/react';
+import { Entity } from '@/types';
+
+export interface UseWorkspaceCallbacksParams {
+  isPublicView: boolean;
+  setSelectedNodeId: (id: string | null) => void;
+  setSelectedEdgeId: (id: string | null) => void;
+  setIsTablePropertiesOpen: (open: boolean) => void;
+  setIsImportModalOpen: (open: boolean) => void;
+  viewportRef: React.MutableRefObject<any>;
+  publicData: any;
+  diagrams: any[];
+  activeDiagramId: any;
+  handleExportSQL: (dialect: 'postgresql' | 'mysql', target: any, nodes: Node<Entity>[], edges: Edge[]) => void;
+  handleExportPDF: (name: string) => void;
+  handleExportImage: (name: string) => void;
+  nodes: Node<Entity>[];
+  edges: Edge[];
+  view: string;
+  isDiagramsLoading: boolean;
+  isERDItemLoading: boolean;
+  isNotesLoading: boolean;
+  isNoteItemLoading: boolean;
+  isDrawingsLoading: boolean;
+  isDrawingItemLoading: boolean;
+  isFlowchartsLoading: boolean;
+  isFlowchartItemLoading: boolean;
+}
+
+export function useWorkspaceCallbacks(params: UseWorkspaceCallbacksParams) {
+  const {
+    isPublicView, setSelectedNodeId, setSelectedEdgeId,
+    setIsTablePropertiesOpen, setIsImportModalOpen,
+    viewportRef,
+    publicData, diagrams, activeDiagramId,
+    handleExportSQL, handleExportPDF, handleExportImage,
+    nodes, edges,
+    view,
+    isDiagramsLoading, isERDItemLoading,
+    isNotesLoading, isNoteItemLoading,
+    isDrawingsLoading, isDrawingItemLoading,
+    isFlowchartsLoading, isFlowchartItemLoading,
+  } = params;
+
+  const handleNodeClick = useCallback((e: React.MouseEvent, n: Node) => {
+    if (!isPublicView && !(e.target as HTMLElement).closest('.nodrag')) setSelectedNodeId(n.id);
+  }, [isPublicView, setSelectedNodeId]);
+
+  const handleNodeDoubleClick = useCallback((e: React.MouseEvent, n: Node) => {
+    if (!isPublicView && !(e.target as HTMLElement).closest('.nodrag')) {
+      setSelectedNodeId(n.id);
+      setIsTablePropertiesOpen(true);
+    }
+  }, [isPublicView, setSelectedNodeId, setIsTablePropertiesOpen]);
+
+  const handleEdgeClick = useCallback((_: any, e: Edge) => {
+    if (!isPublicView) setSelectedEdgeId(e.id);
+  }, [isPublicView, setSelectedEdgeId]);
+
+  const handlePaneClick = useCallback(() => {
+    setSelectedNodeId(null);
+    setSelectedEdgeId(null);
+  }, [setSelectedNodeId, setSelectedEdgeId]);
+
+  const handleMove = useCallback((_: any, v: any) => {
+    viewportRef.current = v;
+  }, [viewportRef]);
+
+  const handleOpenImportModal = useCallback(() => {
+    setIsImportModalOpen(true);
+  }, [setIsImportModalOpen]);
+
+  const handleWorkspaceExportSQL = useCallback((dialect: 'postgresql' | 'mysql') => {
+    const target = isPublicView ? publicData : diagrams.find(f => f.id === activeDiagramId);
+    if (target) handleExportSQL(dialect, target, nodes, edges);
+  }, [isPublicView, publicData, diagrams, activeDiagramId, handleExportSQL, nodes, edges]);
+
+  const handleWorkspaceExportPDF = useCallback(() => {
+    const targetName = isPublicView
+      ? (publicData?.name || 'Shared')
+      : (diagrams.find(f => f.id === activeDiagramId)?.name || 'Diagram');
+    handleExportPDF(targetName);
+  }, [isPublicView, publicData, diagrams, activeDiagramId, handleExportPDF]);
+
+  const handleWorkspaceExportImage = useCallback(() => {
+    const targetName = isPublicView
+      ? (publicData?.name || 'Shared')
+      : (diagrams.find(f => f.id === activeDiagramId)?.name || 'Diagram');
+    handleExportImage(targetName);
+  }, [isPublicView, publicData, diagrams, activeDiagramId, handleExportImage]);
+
+  const workspaceIsLoading = useMemo(() => {
+    if (view === 'erd') return isDiagramsLoading || isERDItemLoading;
+    if (view === 'notes') return isNotesLoading || isNoteItemLoading;
+    if (view === 'drawings') return isDrawingsLoading || isDrawingItemLoading;
+    if (view === 'flowchart') return isFlowchartsLoading || isFlowchartItemLoading;
+    return false;
+  }, [view, isDiagramsLoading, isERDItemLoading, isNotesLoading, isNoteItemLoading, isDrawingsLoading, isDrawingItemLoading, isFlowchartsLoading, isFlowchartItemLoading]);
+
+  return {
+    handleNodeClick,
+    handleNodeDoubleClick,
+    handleEdgeClick,
+    handlePaneClick,
+    handleMove,
+    handleOpenImportModal,
+    handleWorkspaceExportSQL,
+    handleWorkspaceExportPDF,
+    handleWorkspaceExportImage,
+    workspaceIsLoading,
+  };
+}


### PR DESCRIPTION
- create `useWorkspaceCallbacks` hook to encapsulate workspace-related event handlers and logic.
- create `useTrashHandlers` hook to encapsulate trash item handling logic.
- this refactoring improves code organization and reusability by separating concerns into dedicated hooks.