### PR TITLE
fix: stabilize desktop SQLite dev startup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "erd-builder-pro",
-  "version": "2.1.5",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "erd-builder-pro",
-      "version": "2.1.5",
+      "version": "2.2.0",
       "hasInstallScript": true,
       "dependencies": {
         "@aws-sdk/client-s3": "^3.1020.0",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "db:migrate:sqlite": "cross-env DB_VARIANT=sqlite prisma migrate dev",
     "db:push:sqlite": "cross-env DB_VARIANT=sqlite DATABASE_URL=file:./data.db prisma db push",
     "db:seed:sqlite": "rm -rf node_modules/.prisma/client && cross-env DB_VARIANT=sqlite prisma generate && cross-env DB_VARIANT=sqlite DATABASE_URL=file:./data.db tsx prisma/seed.sqlite.ts",
-    "dev:tauri:servers": "concurrently -n api,client \"npm run dev:desktop\" \"VITE_API_URL=http://localhost:3099 npm run dev:client -- --port 3098\"",
+    "dev:desktop:client": "cross-env VITE_API_URL=http://127.0.0.1:3099 vite --port 3098",
+    "dev:tauri:servers": "concurrently -n api,client \"npm run dev:desktop\" \"npm run dev:desktop:client\"",
     "dev:tauri": "npm run build:server && export PATH=\"$HOME/.cargo/bin:$PATH\" && npx tauri dev",
     "dev:desktop": "rm -rf node_modules/.prisma/client && npm run db:generate:sqlite && cross-env PORT=3099 DATABASE_URL=file:./data.db NODE_ENV=development tsx watch server/run.ts"
   },

--- a/server/routes/connections/middleware.ts
+++ b/server/routes/connections/middleware.ts
@@ -1,11 +1,19 @@
-import { Request as ExpressRequest, Response as ExpressResponse, NextFunction } from "express";
+import {
+  Request as ExpressRequest,
+  Response as ExpressResponse,
+  NextFunction,
+} from "express";
 import { prisma } from "../../lib/prisma.js";
 import { isDesktopMode } from "../../lib/config.js";
 import { encrypt, decrypt } from "../../lib/crypto.js";
 import type { ConnectionInfo, DbType } from "../../lib/db-connectors/types.js";
 
 // ── Desktop-only guard ──
-export function desktopOnly(_req: ExpressRequest, res: ExpressResponse, next: NextFunction) {
+export function desktopOnly(
+  _req: ExpressRequest,
+  res: ExpressResponse,
+  next: NextFunction,
+) {
   if (!isDesktopMode()) {
     return res.status(404).json({ error: "Not available" });
   }
@@ -31,7 +39,9 @@ export function buildConnectionInfo(conn: {
   };
 }
 
-export function maskPassword(obj: Record<string, unknown>): Record<string, unknown> {
+export function maskPassword(
+  obj: Record<string, unknown>,
+): Record<string, unknown> {
   return { ...obj, password: (obj as any).password ? "***" : null };
 }
 
@@ -44,21 +54,28 @@ export async function runStartupMigration() {
     // Only run in desktop mode (SQLite) where DbAccount/DbCatalog exist
     if (!isDesktopMode()) return;
 
-    const tables = await prisma.$queryRawUnsafe<{ table_name: string }[]>(
-      "SELECT table_name FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'local_db_connections'"
-    ).catch(() => []);
+    const tables = await prisma
+      .$queryRawUnsafe<
+        { table_name: string }[]
+      >("SELECT name AS table_name FROM sqlite_master WHERE type = 'table' AND name = 'local_db_connections'")
+      .catch(() => []);
     if (!tables || tables.length === 0) return;
 
-    const oldConns = await prisma.$queryRawUnsafe<any[]>(
-      "SELECT * FROM local_db_connections"
-    ).catch(() => []);
+    const oldConns = await prisma
+      .$queryRawUnsafe<any[]>("SELECT * FROM local_db_connections")
+      .catch(() => []);
     if (!oldConns || oldConns.length === 0) return;
 
-    console.log(`[migrate] Migrating ${oldConns.length} local_db_connections → DbAccount + DbCatalog`);
+    console.log(
+      `[migrate] Migrating ${oldConns.length} local_db_connections → DbAccount + DbCatalog`,
+    );
 
     for (const conn of oldConns) {
       const existing = await prisma.dbCatalog.findFirst({
-        where: { account: { userId: conn.user_id }, databaseName: conn.database },
+        where: {
+          account: { userId: conn.user_id },
+          databaseName: conn.database,
+        },
       });
       if (existing) continue;
 
@@ -75,7 +92,11 @@ export async function runStartupMigration() {
       });
 
       const catalog = await prisma.dbCatalog.create({
-        data: { accountId: account.id, databaseName: conn.database, label: conn.name },
+        data: {
+          accountId: account.id,
+          databaseName: conn.database,
+          label: conn.name,
+        },
       });
 
       await prisma.diagram.updateMany({


### PR DESCRIPTION
SQLite desktop mode requires two separate servers, and there was a time when a long process had a port conflict. Finally, we made it a single run with 'npm run dev:tauri:server'.

Changes:
- Use SQLite table metadata for desktop connection migration
- Add a Windows-safe desktop client dev script
- Point desktop client API target to 127.0.0.1:3099
- Update tauri dev server script to reuse the desktop client script