### PR TITLE
fix(ai): surface model lookup error 

### DIFF
--- a/api/ai-proxy.ts
+++ b/api/ai-proxy.ts
@@ -64,11 +64,16 @@ export default async function handler(req: any, res: any) {
     resolvedBaseUrl = resolvedBaseUrl || config.ai_providers?.base_url || "https://api.openai.com/v1";
 
     if (!resolvedModel && config.selected_model_id) {
-      const { data: modelData } = await supabase
+      const { data: modelData, error: modelError } = await supabase
         .from("ai_models")
         .select("model_identifier")
         .eq("id", config.selected_model_id)
         .single();
+
+      if (modelError) {
+        return res.status(400).json({ error: "Failed to fetch the selected AI model" });
+      }
+
       resolvedModel = modelData?.model_identifier || "gpt-4o-mini";
     }
   }


### PR DESCRIPTION
## Problem

`api/ai-proxy.ts` discards the `error` from the `ai_models` lookup, so a failed
lookup falls through to `modelData?.model_identifier || "gpt-4o-mini"`. The RLS
read policy on `ai_models` is scoped to `is_active = true`, so deactivating a
model in the catalog silently reroutes every user who selected it to
`gpt-4o-mini` — against their own API key, with no error surfaced.

`selected_model_id` is `ON DELETE SET NULL`, so a deleted model is handled;
a deactivated one is not.

## Fix

Destructure `error` and return 400, matching how `configError` is handled
twelve lines above in the same function.

## Notes

Found this with [api-doctor](https://github.com/qualtyco/api-doctor), an oxlint plugin for API integration
patterns. Happy to remove this note if it's noise.